### PR TITLE
Fixed numpy 2.x namespace bugs

### DIFF
--- a/src/pygenray/integration_processes.py
+++ b/src/pygenray/integration_processes.py
@@ -387,7 +387,7 @@ def ray_angle(
     """
 
     c = bilinear_interp(x, y[1], rin, zin, cin)
-    theta = np.degrees(np.asin(y[2] * c))
+    theta = np.degrees(np.arcsin(y[2] * c))
     return theta,c
 
 

--- a/src/pygenray/launch_rays.py
+++ b/src/pygenray/launch_rays.py
@@ -276,7 +276,7 @@ def _shoot_ray_array(
 
     # initialize loop parameters
     x_intermediate = source_range
-    full_ray = np.concat((np.array([source_range]), y0)).copy()
+    full_ray = np.concatenate((np.array([source_range]), y0)).copy()
     full_ray = np.expand_dims(full_ray, axis=1)
     sols = []
     n_surface = 0


### PR DESCRIPTION
`np.concat` and `np.asin` caused compile errors with numba. changed to `np.concatenate` and `np.arcsin`