### PR TITLE
updated to spawn processes instead of fork

### DIFF
--- a/src/pygenray/eigenrays.py
+++ b/src/pygenray/eigenrays.py
@@ -127,7 +127,7 @@ def find_eigenrays(
             # map individual eigen ray finding to different workers
             if num_workers is None:
                 num_workers = mp.cpu_count()
-            with mp.Pool(num_workers) as pool:
+            with mp.get_context('spawn').Pool(num_workers) as pool:
                 results = list(tqdm(pool.imap(_find_single_eigenray, args_list), total=len(args_list), desc="Finding eigenrays"))
             
             # Filter out None results and add successful rays

--- a/src/pygenray/environment.py
+++ b/src/pygenray/environment.py
@@ -347,7 +347,7 @@ def _process_ranges_chunked_parallel(c, r_chunks, n_cpus):
     
     # Run in parallel with progress bar
     all_results = []
-    with mp.Pool(processes=n_cpus) as pool:
+    with mp.get_context('spawn').Pool(processes=n_cpus) as pool:
         for chunk_results in tqdm(
             pool.imap(_process_chunk_worker, args_list), 
             total=len(r_chunks),

--- a/src/pygenray/launch_rays.py
+++ b/src/pygenray/launch_rays.py
@@ -127,7 +127,7 @@ def shoot_rays(
                 terminate_backwards=terminate_backwards
             )
             
-            with mp.Pool(n_processes) as pool:
+            with mp.get_context('spawn').Pool(n_processes) as pool:
                 rays_ls = list(tqdm(pool.imap(shoot_ray_part, y0s), total=len(y0s), desc="Computing ray fan"))
 
             ranges = np.linspace(source_range, receiver_range, num_range_save)


### PR DESCRIPTION
Causes warnings when pygenray is run in environments where jax is also imported